### PR TITLE
Change the computation of live exits to do a fixpoint

### DIFF
--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -18,16 +18,12 @@
 
 open Mach
 
-module IntSet = Set.Make(
-  struct
-    type t = int
-    let compare (x:t) y = compare x y
-  end)
+module Int = Identifiable.Make (Numbers.Int)
 
 type d = {
   i : instruction;   (* optimized instruction *)
   regs : Reg.Set.t;  (* a set of registers live "before" instruction [i] *)
-  exits : IntSet.t;  (* indexes of Iexit instructions "live before" [i] *)
+  exits : Int.Set.t;  (* indexes of Iexit instructions "live before" [i] *)
 }
 
 let rec deadcode i =
@@ -39,12 +35,12 @@ let rec deadcode i =
   in
   match i.desc with
   | Iend | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) | Iraise _ ->
-    let regs = Reg.add_set_array i.live arg in
-    { i; regs; exits = IntSet.empty; }
+      let regs = Reg.add_set_array i.live arg in
+      { i; regs; exits = Int.Set.empty; }
   | Iop op ->
       let s = deadcode i.next in
       if Proc.op_is_pure op                     (* no side effects *)
-      && Reg.disjoint_set_array s.regs i.res (* results are not used after *)
+      && Reg.disjoint_set_array s.regs i.res   (* results are not used after *)
       && not (Proc.regs_are_volatile arg)      (* no stack-like hard reg *)
       && not (Proc.regs_are_volatile i.res)    (*            is involved *)
       then begin
@@ -62,8 +58,8 @@ let rec deadcode i =
       let s = deadcode i.next in
       { i = {i with desc = Iifthenelse(test, ifso'.i, ifnot'.i); next = s.i};
         regs = Reg.add_set_array i.live arg;
-        exits = IntSet.union s.exits
-                  (IntSet.union ifso'.exits ifnot'.exits);
+        exits = Int.Set.union s.exits
+                  (Int.Set.union ifso'.exits ifnot'.exits);
       }
   | Iswitch(index, cases) ->
       let dc = Array.map deadcode cases in
@@ -72,65 +68,40 @@ let rec deadcode i =
       { i = {i with desc = Iswitch(index, cases'); next = s.i};
         regs = Reg.add_set_array i.live arg;
         exits = Array.fold_left
-                  (fun acc c -> IntSet.union acc c.exits) s.exits dc;
+                  (fun acc c -> Int.Set.union acc c.exits) s.exits dc;
       }
   | Icatch(rec_flag, handlers, body) ->
     let body' = deadcode body in
     let s = deadcode i.next in
-    let (handlers', h_exits) =
-      List.split
-        (List.map (fun (nfail, handler) ->
-           let handler' = deadcode handler in
-           ((nfail, handler'.i), handler'.exits))
-           handlers)
+    let handlers' = Int.Map.map deadcode (Int.Map.of_list handlers) in
+    let rec add_live exit (live_exits, used_handlers) =
+      if Int.Set.mem exit live_exits then
+        (live_exits, used_handlers)
+      else
+        let live_exits = Int.Set.add exit live_exits in
+        match Int.Map.find_opt exit handlers' with
+        | None -> (live_exits, used_handlers)
+        | Some handler ->
+            Int.Set.fold add_live handler.exits
+              (live_exits, (exit, handler.i) :: used_handlers)
     in
-    (* Remove unused handlers.
-       We deal with three disjoint sets of "nfail" indexes:
-       dead handler indexes = B \setminus A
-       used handler indexes = A \intersect B
-       live exit indexes = A \setminus B
-       where
-       B = indexes of handlers in this Icatch,
-       A = indexes used in Iexit instructions that are
-       in scope of the handlers of this Icatch (scope depends on rec_flag).
-    *)
-    let h_exits = List.fold_left (fun acc e -> IntSet.union acc e)
-                    IntSet.empty h_exits in
-    let all_exits = IntSet.union body'.exits h_exits in
-    let exits_in_scope =
-      match rec_flag with
-      | Cmm.Recursive -> all_exits
-        (* Indexes mentioned in Iexit instructions in body and handlers. *)
-      | Cmm.Nonrecursive -> body'.exits
-        (* Icatch body is allowed to Iexit to it's own hanlders
-           or handlers of an enclosing Icatch that are not shadowed
-           by the current Icatch.
-           A handler cannot Iexit to itself or other handlers in this Icatch.
-           Thus, all Iexits in handlers refer to an enclosing Icatch. *)
+    let live_exits, used_handlers =
+      Int.Set.fold add_live body'.exits (s.exits, [])
     in
-    (* A handler is "used" if and only if its index is in exits_in_scope .*)
-    let used_handlers =
-      List.filter (fun (n,_)-> IntSet.mem n exits_in_scope) handlers' in
-    let used_handler_indexes =
-      IntSet.of_list (fst (List.split used_handlers)) in
-    (* Exits that do not have a used handler with the same index
-       are referring to a handler in an enclosing catch.
-       They are added to "live before" exits of instruction [i] *)
-    let live_exits = IntSet.diff all_exits used_handler_indexes in
     { i = {i with desc = Icatch(rec_flag, used_handlers, body'.i); next = s.i};
       regs = i.live;
-      exits = IntSet.union s.exits live_exits;
+      exits = live_exits;
     }
   | Iexit nfail ->
-      { i;  regs = i.live; exits = IntSet.singleton nfail; }
+      { i;  regs = i.live; exits = Int.Set.singleton nfail; }
   | Itrywith(body, handler) ->
       let body' = deadcode body in
       let handler' = deadcode handler in
       let s = deadcode i.next in
       { i = {i with desc = Itrywith(body'.i, handler'.i); next = s.i};
         regs = i.live;
-        exits = IntSet.union s.exits
-                  (IntSet.union body'.exits handler'.exits);
+        exits = Int.Set.union s.exits
+                  (Int.Set.union body'.exits handler'.exits);
       }
 
 let fundecl f =


### PR DESCRIPTION
Some branches could be considered live if only used by handles, while being unreachable by the body.

I replaced IntSet to Int.Set because I needed a IntMap and it was a bit shorter to use Identifiable.